### PR TITLE
Fix slide id lookup in slide include

### DIFF
--- a/_includes/slide.html
+++ b/_includes/slide.html
@@ -1,4 +1,5 @@
-<section {% if post.slide-id %}id="{{post.slide-id}}"{%endif %} class="step{%if post.classes | size %}{% for class in post.classes %} {{class}}{% endfor %}{% else %} slide{% endif %}" {% unless site.simple-slideshow %}{% for attr in post.data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}{% endunless %}>
+{% assign slide_id = post["slide-id"] %}
+<section {% if slide_id %}id="{{ slide_id }}"{%endif %} class="step{%if post.classes | size %}{% for class in post.classes %} {{class}}{% endfor %}{% else %} slide{% endif %}" {% unless site.simple-slideshow %}{% for attr in post.data %} data-{{attr[0]}}="{{attr[1]}}"{% endfor %}{% endunless %}>
   {% if post.title != "" %}<h1>{{ post.title }}</h1>{% endif %}
 
   {{ post.content }}


### PR DESCRIPTION
## Summary
- correctly read the `slide-id` front matter key without triggering Liquid errors
- preserve the existing slide markup while ensuring the include has a trailing newline

## Testing
- not run (ruby dependencies could not be installed in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913731e0ddc832091555cb161ac6783)